### PR TITLE
Fix queen legal moves return

### DIFF
--- a/chess/engine/pieces/queen.py
+++ b/chess/engine/pieces/queen.py
@@ -15,7 +15,7 @@ class Queen(Piece):
     def __init__(self, position: int, alliance: Alliance) -> None:
         super().__init__(position, alliance)
 
-    def calculate_legal_moves(self, board: Board):
+    def calculate_legal_moves(self, board: Board) -> set[Move]:
         from chess.engine.board import is_valid_position
 
         self.legal_moves.clear()
@@ -42,6 +42,8 @@ class Queen(Piece):
                             AttackMove(self, possible_target, piece_on_tile)
                         )
                     break
+
+        return self.legal_moves
 
 
 def is_first_column_exclusion(position: int, offset: int) -> bool:


### PR DESCRIPTION
## Summary
- return `self.legal_moves` from `Queen.calculate_legal_moves`
- add return type annotation so queen mirrors other pieces

## Testing
- `pip install -r requirements.txt` *(fails: Could not find PySide6)*
- `pytest -q tests/test_pieces.py::TestKnight.test_legal_moves` *(fails: pytest not installed)*