### PR TITLE
Fix parameter typo

### DIFF
--- a/chess/engine/pieces/bishop.py
+++ b/chess/engine/pieces/bishop.py
@@ -52,7 +52,7 @@ def is_eighth_column_exclusion(position: int, offset: int) -> bool:
     return position % 8 == 7 and offset in (-7, 9)
 
 
-def is_restricted_move(positon: int, offset: int) -> bool:
-    return is_first_column_exclusion(positon, offset) or is_eighth_column_exclusion(
-        positon, offset
+def is_restricted_move(position: int, offset: int) -> bool:
+    return is_first_column_exclusion(position, offset) or is_eighth_column_exclusion(
+        position, offset
     )

--- a/chess/engine/pieces/queen.py
+++ b/chess/engine/pieces/queen.py
@@ -54,7 +54,7 @@ def is_eighth_column_exclusion(position: int, offset: int) -> bool:
     return position % 8 == 7 and offset in (-7, 1, 9)
 
 
-def is_restricted_move(positon: int, offset: int) -> bool:
-    return is_first_column_exclusion(positon, offset) or is_eighth_column_exclusion(
-        positon, offset
+def is_restricted_move(position: int, offset: int) -> bool:
+    return is_first_column_exclusion(position, offset) or is_eighth_column_exclusion(
+        position, offset
     )


### PR DESCRIPTION
## Summary
- fix param name `positon` -> `position` in Bishop and Queen helpers

## Testing
- `python -m py_compile chess/engine/pieces/bishop.py chess/engine/pieces/queen.py`